### PR TITLE
Update latest and fix sending messages to Kurento

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,12 @@ var inject = require('reconnect-core');
 module.exports = inject(function () {
   // Create new websocket-stream instance
   var args = [].slice.call(arguments);
+  // Default ws object mode
+  if (!args[1]) {
+    args.push({objectMode: true})
+  } else if (!args[1].objectMode) {
+    args[1].objectMode = true;
+  }
   var ws = websocket.apply(null, args);
 
   // Copy buffer from old websocket-stream instance on the new one

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/jacobbubu/reconnect-ws",
   "dependencies": {
     "reconnect-core": "KurentoForks/reconnect-core",
-    "websocket-stream": "^3.3.3"
+    "websocket-stream": "^5.5.0"
   },
   "devDependencies": {
     "ws": "~1.1.1"


### PR DESCRIPTION
Update websocket-stream to latest version and default to use object mode. 
If we don't use object mode, we will be sending more than one JSON at the same time to Kurento causing a Time Out error.